### PR TITLE
feat: User API 나머지 기능 구현

### DIFF
--- a/src/users/dtos/create-user.dto.ts
+++ b/src/users/dtos/create-user.dto.ts
@@ -20,23 +20,3 @@ export class CreateUserDto {
   @IsEnum(UserType, { message: '회원 유형은 BUYER 또는 SELLER 여야 합니다.' })
   type: UserType;
 }
-
-export interface GradeResponseDto {
-  id: string;
-  name: string;
-  rate: number;
-  minAmount: number;
-}
-
-export interface UserResponseDto {
-  id: string;
-  name: string;
-  email: string;
-  password: string;
-  type: string;
-  points: number | null;
-  createdAt: Date;
-  updatedAt: Date;
-  image: string | null;
-  grade: GradeResponseDto;
-}

--- a/src/users/dtos/update-user.dto.ts
+++ b/src/users/dtos/update-user.dto.ts
@@ -1,0 +1,23 @@
+import { IsOptional, IsNotEmpty, IsString, MinLength, MaxLength } from 'class-validator';
+
+export class UpdateUserDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(100)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  image?: string;
+
+  @IsNotEmpty()
+  @IsString()
+  currentPassword: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(2, { message: '비밀번호는 최소 2자 이상이어야 합니다.' })
+  @MaxLength(50, { message: '비밀번호는 최대 50자 이하여야 합니다.' })
+  password?: string;
+}

--- a/src/users/dtos/user-response.ts
+++ b/src/users/dtos/user-response.ts
@@ -1,0 +1,38 @@
+import { UserType } from '@prisma/client';
+
+export interface GradeResponseDto {
+  id: string;
+  name: string;
+  rate: number;
+  minAmount: number;
+}
+
+export interface UserMapperDto {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+  type: UserType;
+  points: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+  grade: GradeResponseDto;
+  image: string | null;
+}
+
+export class UserMapper {
+  static toUserResponse(user: UserMapperDto) {
+    return {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      password: user.password,
+      type: user.type,
+      points: user.points,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+      grade: user.grade,
+      image: user.image,
+    };
+  }
+}

--- a/src/users/user.controller.ts
+++ b/src/users/user.controller.ts
@@ -1,6 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { CreateUserDto } from './dtos/create-user.dto';
+import { UpdateUserDto } from './dtos/update-user.dto';
 import UserService from './user.service';
+import { NotFoundError } from '../common/errors/error-type';
 
 export default class UserController {
   private readonly userService: UserService;
@@ -9,6 +11,7 @@ export default class UserController {
     this.userService = userService;
   }
 
+  // 회원가입
   createUser = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const data: CreateUserDto = req.body;
@@ -16,6 +19,68 @@ export default class UserController {
       const response = await this.userService.createUser(data);
 
       res.status(201).json(response);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  // 내 정보 조회
+  getUser = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.user?.id;
+
+      if (!userId) {
+        throw new NotFoundError('유저를 찾을 수 없습니다.');
+      }
+
+      const response = await this.userService.getUser(userId);
+      res.status(200).json(response);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  // 내 정보 수정
+  updateUser = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        throw new NotFoundError('유저를 찾을 수 없습니다.');
+      }
+      const data: UpdateUserDto = req.body;
+      const response = await this.userService.updateUser(userId, data);
+
+      res.status(200).json(response);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  // 관심 스토어 조회
+  getUserLikedStores = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        throw new NotFoundError('유저를 찾을 수 없습니다.');
+      }
+
+      const response = await this.userService.getUserLikedStores(userId);
+      res.status(200).json(response);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  // 회원 탈퇴
+  deleteUser = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        throw new NotFoundError('유저를 찾을 수 없습니다.');
+      }
+
+      const response = await this.userService.deleteUser(userId);
+      res.status(200).json(response);
     } catch (error) {
       next(error);
     }

--- a/src/users/user.repository.ts
+++ b/src/users/user.repository.ts
@@ -19,4 +19,31 @@ export default class UserRepository {
       include: { grade: true },
     });
   }
+  async getUserById(id: string) {
+    return this.prisma.user.findUnique({
+      where: { id },
+      include: { grade: true },
+    });
+  }
+
+  async updateUser(id: string, data: Prisma.UserUpdateInput) {
+    return this.prisma.user.update({
+      where: { id },
+      data,
+      include: { grade: true },
+    });
+  }
+
+  async getUserLikedStores(userId: string) {
+    return this.prisma.storeLike.findMany({
+      where: { userId },
+      include: { store: true },
+    });
+  }
+
+  async deleteUser(id: string) {
+    return this.prisma.user.delete({
+      where: { id },
+    });
+  }
 }

--- a/src/users/user.routes.ts
+++ b/src/users/user.routes.ts
@@ -5,13 +5,34 @@ import UserService from './user.service';
 import UserController from './user.controller';
 import validateDto from '../common/utils/validate.dto';
 import { CreateUserDto } from './dtos/create-user.dto';
+import { UpdateUserDto } from './dtos/update-user.dto';
+import passport from 'passport';
+import { authorizeBuyer } from '../middleware/authorization';
 
 const router = Router();
 const userRepository = new UserRepository(prisma);
 const userService = new UserService(userRepository);
 const userController = new UserController(userService);
 
-// 회원가입 API
+// 회원가입
 router.post('/', validateDto(CreateUserDto), userController.createUser);
+// 내 정보 조회
+router.get('/me', passport.authenticate('jwt', { session: false }), userController.getUser);
+// 내 정보 수정
+router.patch(
+  '/me',
+  validateDto(UpdateUserDto),
+  passport.authenticate('jwt', { session: false }),
+  userController.updateUser
+);
+// 관심 스토어 조회
+router.get(
+  '/me/likes',
+  passport.authenticate('jwt', { session: false }),
+  authorizeBuyer,
+  userController.getUserLikedStores
+);
+// 회원 탈퇴
+router.delete('/me', passport.authenticate('jwt', { session: false }), userController.deleteUser);
 
 export default router;

--- a/src/users/user.routes.ts
+++ b/src/users/user.routes.ts
@@ -7,7 +7,6 @@ import validateDto from '../common/utils/validate.dto';
 import { CreateUserDto } from './dtos/create-user.dto';
 import { UpdateUserDto } from './dtos/update-user.dto';
 import passport from 'passport';
-import { authorizeBuyer } from '../middleware/authorization';
 
 const router = Router();
 const userRepository = new UserRepository(prisma);
@@ -29,7 +28,6 @@ router.patch(
 router.get(
   '/me/likes',
   passport.authenticate('jwt', { session: false }),
-  authorizeBuyer,
   userController.getUserLikedStores
 );
 // 회원 탈퇴


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- PR과 관련된 이슈 번호를 작성 -->
<!-- 작업 사항: 작업 사항들을 간단하게 작성 -->
<!-- 참고자료: Screenshot/GIF, 관련 문서, 링크 등을 작성 -->
<!-- 리뷰어에게: 요청사항이나 참고할 점을 작성 -->


## 🔗 관련 이슈들
- issue #13 

## 🧾 작업 사항
- 내 정보 조회, 수정, 관심스토어 조회, 회원탈퇴 기능을 구현했습니다.
- schema 상으로는 `isDeleted` 라는 소프트 딜리트를 위한 필드가 작성되어있지만,  
  소프트 딜리트 구현을 위해선 각 기능들에 추가 코드를 작성해야 하기 때문에,  
  임시로 회원 탈퇴 코드 구현은 하드딜리트로 작성하였고, 소프트 딜리트의 구현 여부는 아직 고민중에 있습니다.
- 프론트 UI 상으로 관심스토어 등록,헤제는 판매,구매자 둘 다 가능하지만,  
  관심 스토어 조회UI는 구매자만 구현이 되어 있었기 때문에 `authorizeBuyer` 미들웨어를 적용했습니다.


## 📎 참고 자료(선택)


## 💬 리뷰어에게(선택)
