### PR TITLE
feat: 문의 api 기능 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,7 +21,7 @@ model User {
   email     String   @unique @db.VarChar(100)
   password  String   @db.VarChar(255)
   image     String?  @default("https://example.com/default.png") // 추후 기본값 수정
-  points    Int     @default(0)
+  points    Int      @default(0)
   type      UserType
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -222,7 +222,7 @@ enum InquiryStatus {
 model InquiryReply {
   id        String   @id @default(cuid())
   inquiryId String   @unique
-  userId    String   
+  userId    String
   content   String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -234,6 +234,7 @@ model InquiryReply {
 enum NotificationType {
   BUYER_SOLD_OUT
   BUYER_INQUIRY_ANSWERED
+  BUYER_RESTOCKED
   SELLER_SOLD_OUT
   SELLET_NEW_INQUIRY
 }
@@ -243,6 +244,7 @@ model Notification {
   userId    String
   content   String
   type      NotificationType
+  size      String?
   isChecked Boolean          @default(false)
   createdAt DateTime         @default(now())
   updatedAt DateTime         @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,12 +91,12 @@ model Product {
   isSoldOut         Boolean   @default(false)
   categoryId        String?
 
-  store    Store     @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  store    Store      @relation(fields: [storeId], references: [id], onDelete: Cascade)
   CartItem CartItem[]
   Review   Review[]
   Stock    Stock[]
   Inquiry  Inquiry[]
-  Category Category? @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  Category Category?  @relation(fields: [categoryId], references: [id], onDelete: Cascade)
 
   @@index([name])
 }
@@ -231,13 +231,21 @@ model InquiryReply {
   user    User    @relation(fields: [userId], references: [id])
 }
 
+enum NotificationType {
+  BUYER_SOLD_OUT
+  BUYER_INQUIRY_ANSWERED
+  SELLER_SOLD_OUT
+  SELLET_NEW_INQUIRY
+}
+
 model Notification {
-  id        String   @id @default(cuid())
+  id        String           @id @default(cuid())
   userId    String
   content   String
-  isChecked Boolean  @default(false)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  type      NotificationType
+  isChecked Boolean          @default(false)
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
 
   user User @relation(fields: [userId], references: [id])
 }
@@ -253,8 +261,8 @@ model Size {
 }
 
 model Category {
-  id        String @id @default(cuid())
-  name      String @unique
+  id   String @id @default(cuid())
+  name String @unique
 
   product Product[]
 }

--- a/src/index.routes.ts
+++ b/src/index.routes.ts
@@ -5,6 +5,7 @@ import userRouter from './users/user.routes';
 import authRouter from './auth/auth.routes';
 import StoresRouter from './stores/store.routes';
 import productRouter from './product/product.route';
+import NotificationRouter from './notification/notification.routes';
 
 const router = express.Router();
 
@@ -12,5 +13,6 @@ router.use('/users', userRouter);
 router.use('/auth', authRouter);
 router.use('/products', productRouter);
 router.use('/stores', StoresRouter(prisma));
+router.use('/notifications', NotificationRouter(prisma));
 
 export default router;

--- a/src/notification/dto/create.dto.ts
+++ b/src/notification/dto/create.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateNotificationDto {
+  @IsNotEmpty()
+  @IsString()
+  content: string;
+}

--- a/src/notification/dto/create.dto.ts
+++ b/src/notification/dto/create.dto.ts
@@ -1,7 +1,12 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { NotificationType } from '@prisma/client';
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateNotificationDto {
   @IsNotEmpty()
   @IsString()
   content: string;
+
+  @IsNotEmpty()
+  @IsEnum(NotificationType)
+  type: NotificationType;
 }

--- a/src/notification/dto/create.dto.ts
+++ b/src/notification/dto/create.dto.ts
@@ -1,5 +1,5 @@
 import { NotificationType } from '@prisma/client';
-import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateNotificationDto {
   @IsNotEmpty()
@@ -9,4 +9,8 @@ export class CreateNotificationDto {
   @IsNotEmpty()
   @IsEnum(NotificationType)
   type: NotificationType;
+
+  @IsOptional()
+  @IsString()
+  size?: string;
 }

--- a/src/notification/dto/response.dto.ts
+++ b/src/notification/dto/response.dto.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import { IsDateString, IsNotEmpty, IsString } from 'class-validator';
+import { IsBoolean, IsDateString, IsNotEmpty, IsString } from 'class-validator';
 
 export class NotificationResponseDto {
   @IsNotEmpty()
@@ -10,7 +10,7 @@ export class NotificationResponseDto {
   @IsNotEmpty()
   @IsString()
   @Expose()
-  userid: string;
+  userId: string;
 
   @IsNotEmpty()
   @IsString()
@@ -18,7 +18,7 @@ export class NotificationResponseDto {
   content: string;
 
   @IsNotEmpty()
-  @IsString()
+  @IsBoolean()
   @Expose()
   isChecked: boolean;
 

--- a/src/notification/dto/response.dto.ts
+++ b/src/notification/dto/response.dto.ts
@@ -1,0 +1,34 @@
+import { Expose } from 'class-transformer';
+import { IsDateString, IsNotEmpty, IsString } from 'class-validator';
+
+export class NotificationResponseDto {
+  @IsNotEmpty()
+  @IsString()
+  @Expose()
+  id: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Expose()
+  userid: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Expose()
+  content: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Expose()
+  isChecked: boolean;
+
+  @IsDateString()
+  @IsNotEmpty()
+  @Expose()
+  createdAt: string;
+
+  @IsDateString()
+  @IsNotEmpty()
+  @Expose()
+  updatedAt: string;
+}

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -1,0 +1,82 @@
+import { NextFunction, Request, Response } from 'express';
+import { NotificationService } from './notification.service';
+import { plainToInstance } from 'class-transformer';
+import { NotificationResponseDto } from './dto/response.dto';
+import { CreateNotificationDto } from './dto/create.dto';
+import { validate } from 'class-validator';
+
+export class NotificationController {
+  private readonly notificationService: NotificationService;
+
+  constructor(notificationService: NotificationService) {
+    this.notificationService = notificationService;
+  }
+
+  sseConnect = (req: Request, res: Response) => {
+    res.writeHead(200, {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    });
+
+    const removeClient = this.notificationService.addClient(res);
+
+    req.on('close', () => {
+      removeClient();
+    });
+  };
+
+  getNotifications = async (req: Request, res: Response, next: NextFunction) => {
+    const { userId } = req.query;
+
+    if (!userId || typeof userId !== 'string') {
+      return res.status(400).json({ message: 'User ID is required.' });
+    }
+    try {
+      const notifications = await this.notificationService.getNotification(userId);
+      const notificationsResponse = plainToInstance(NotificationResponseDto, notifications, {
+        excludeExtraneousValues: true,
+      });
+      res.status(200).json(notificationsResponse);
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  checkNotification = async (req: Request, res: Response, next: NextFunction) => {
+    const { alarmId } = req.params;
+    if (!alarmId || typeof alarmId !== 'string') {
+      return res.status(400).json({ message: 'Alarm ID is required.' });
+    }
+    try {
+      const checkedNotification = await this.notificationService.checkNotification(alarmId);
+      const ckNotificationResponse = plainToInstance(NotificationResponseDto, checkedNotification, {
+        excludeExtraneousValues: true,
+      });
+      res.status(200).json(ckNotificationResponse);
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  triggerNotification = async (req: Request, res: Response, next: NextFunction) => {
+    const { userId, content, type } = req.body;
+    const dto = plainToInstance(CreateNotificationDto, { content, type });
+    const errors = await validate(dto);
+
+    if (errors.length > 0) {
+      return res.status(400).json({ errors: errors.map((err) => err.constraints) });
+    }
+
+    if (!userId) {
+      return res.status(400).json({ message: 'User ID is required in the body.' });
+    }
+
+    try {
+      const newNotification = await this.notificationService.createAndSendNotification(userId, dto);
+      res.status(201).json(newNotification);
+    } catch (error) {
+      return next(error);
+    }
+  };
+}

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -2,8 +2,6 @@ import { NextFunction, Request, Response } from 'express';
 import { NotificationService } from './notification.service';
 import { plainToInstance } from 'class-transformer';
 import { NotificationResponseDto } from './dto/response.dto';
-import { CreateNotificationDto } from './dto/create.dto';
-import { validate } from 'class-validator';
 
 export class NotificationController {
   private readonly notificationService: NotificationService;
@@ -54,27 +52,6 @@ export class NotificationController {
         excludeExtraneousValues: true,
       });
       res.status(200).json(ckNotificationResponse);
-    } catch (error) {
-      return next(error);
-    }
-  };
-
-  triggerNotification = async (req: Request, res: Response, next: NextFunction) => {
-    const { userId, content, type } = req.body;
-    const dto = plainToInstance(CreateNotificationDto, { content, type });
-    const errors = await validate(dto);
-
-    if (errors.length > 0) {
-      return res.status(400).json({ errors: errors.map((err) => err.constraints) });
-    }
-
-    if (!userId) {
-      return res.status(400).json({ message: 'User ID is required in the body.' });
-    }
-
-    try {
-      const newNotification = await this.notificationService.createAndSendNotification(userId, dto);
-      res.status(201).json(newNotification);
     } catch (error) {
       return next(error);
     }

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -47,11 +47,8 @@ export class NotificationController {
       return res.status(400).json({ message: 'Alarm ID is required.' });
     }
     try {
-      const checkedNotification = await this.notificationService.checkNotification(alarmId);
-      const ckNotificationResponse = plainToInstance(NotificationResponseDto, checkedNotification, {
-        excludeExtraneousValues: true,
-      });
-      res.status(200).json(ckNotificationResponse);
+      await this.notificationService.checkNotification(alarmId);
+      res.status(200).send();
     } catch (error) {
       return next(error);
     }

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -33,7 +33,7 @@ export class NotificationController {
       return res.status(400).json({ message: 'User ID is required.' });
     }
     try {
-      const notifications = await this.notificationService.getNotification(userId);
+      const notifications = await this.notificationService.getNotifications(userId);
       const notificationsResponse = plainToInstance(NotificationResponseDto, notifications, {
         excludeExtraneousValues: true,
       });

--- a/src/notification/notification.repository.ts
+++ b/src/notification/notification.repository.ts
@@ -1,0 +1,35 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+
+export class NotificationRepository {
+  private readonly prisma: PrismaClient | Prisma.TransactionClient;
+
+  constructor(prisma: PrismaClient | Prisma.TransactionClient) {
+    this.prisma = prisma;
+  }
+
+  async createNotification(data: Prisma.NotificationCreateInput) {
+    return this.prisma.notification.create({
+      data,
+    });
+  }
+
+  async findByUserId(userId: string) {
+    return this.prisma.notification.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findById(id: string) {
+    return this.prisma.notification.findUnique({
+      where: { id },
+    });
+  }
+
+  async updateNotification(id: string, data: Prisma.NotificationUpdateInput) {
+    return this.prisma.notification.update({
+      where: { id },
+      data,
+    });
+  }
+}

--- a/src/notification/notification.routes.ts
+++ b/src/notification/notification.routes.ts
@@ -3,6 +3,7 @@ import { NotificationRepository } from './notification.repository';
 import { NotificationService } from './notification.service';
 import { NotificationController } from './notification.controller';
 import { PrismaClient } from '@prisma/client';
+import passport from 'passport';
 
 const NotificationRouter = (prisma: PrismaClient): Router => {
   const router = Router();
@@ -11,9 +12,21 @@ const NotificationRouter = (prisma: PrismaClient): Router => {
   const notificationService = new NotificationService(notificationRepository);
   const notificationController = new NotificationController(notificationService);
 
-  router.get('/sse', notificationController.sseConnect);
-  router.get('/', notificationController.getNotifications);
-  router.patch('/:alarmId/check', notificationController.checkNotification);
+  router.get(
+    '/sse',
+    passport.authenticate('jwt', { session: false }),
+    notificationController.sseConnect
+  );
+  router.get(
+    '/',
+    passport.authenticate('jwt', { session: false }),
+    notificationController.getNotifications
+  );
+  router.patch(
+    '/:alarmId/check',
+    passport.authenticate('jwt', { session: false }),
+    notificationController.checkNotification
+  );
 
   return router;
 };

--- a/src/notification/notification.routes.ts
+++ b/src/notification/notification.routes.ts
@@ -15,8 +15,6 @@ const NotificationRouter = (prisma: PrismaClient): Router => {
   router.get('/', notificationController.getNotifications);
   router.patch('/:alarmId/check', notificationController.checkNotification);
 
-  router.post('/trigger', notificationController.triggerNotification);
-
   return router;
 };
 

--- a/src/notification/notification.routes.ts
+++ b/src/notification/notification.routes.ts
@@ -1,0 +1,23 @@
+import { Router } from 'express';
+import { NotificationRepository } from './notification.repository';
+import { NotificationService } from './notification.service';
+import { NotificationController } from './notification.controller';
+import { PrismaClient } from '@prisma/client';
+
+const NotificationRouter = (prisma: PrismaClient): Router => {
+  const router = Router();
+
+  const notificationRepository = new NotificationRepository(prisma);
+  const notificationService = new NotificationService(notificationRepository);
+  const notificationController = new NotificationController(notificationService);
+
+  router.get('/sse', notificationController.sseConnect);
+  router.get('/', notificationController.getNotifications);
+  router.patch('/:alarmId/check', notificationController.checkNotification);
+
+  router.post('/trigger', notificationController.triggerNotification);
+
+  return router;
+};
+
+export default NotificationRouter;

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -52,10 +52,9 @@ export class NotificationService {
     return plainToInstance(NotificationResponseDto, notificationList);
   }
 
-  async checkNotification(id: string): Promise<NotificationResponseDto> {
-    const checkNotification = await this.notificationRepository.updateNotification(id, {
+  async checkNotification(id: string): Promise<void> {
+    await this.notificationRepository.updateNotification(id, {
       isChecked: true,
     });
-    return plainToInstance(NotificationResponseDto, checkNotification);
   }
 }

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -1,0 +1,61 @@
+import { plainToInstance } from 'class-transformer';
+import { CreateNotificationDto } from './dto/create.dto';
+import { NotificationResponseDto } from './dto/response.dto';
+import { NotificationRepository } from './notification.repository';
+
+type SseClient = import('express').Response;
+
+export class NotificationService {
+  private readonly notificationRepository: NotificationRepository;
+  private readonly clients = new Set<SseClient>();
+
+  constructor(notificationRepository: NotificationRepository) {
+    this.notificationRepository = notificationRepository;
+  }
+
+  addClient(res: SseClient): () => void {
+    this.clients.add(res);
+    console.log(`새로운 SSE 클라이언트 연결`);
+
+    return () => {
+      this.clients.delete(res);
+      console.log(`SSE 클라이언트 연결 종료`);
+    };
+  }
+
+  async createAndSendNotification(
+    userId: string,
+    dto: CreateNotificationDto
+  ): Promise<NotificationResponseDto> {
+    const newNotification = await this.notificationRepository.createNotification({
+      user: {
+        connect: {
+          id: userId,
+        },
+      },
+      type: dto.type,
+      content: dto.content,
+    });
+
+    const data = JSON.stringify(newNotification);
+    this.clients.forEach((client) => {
+      client.write(`id: ${newNotification.id}\n`);
+      client.write(`event: new_notification\n`);
+      client.write(`data: ${data}\n\n`);
+    });
+
+    return plainToInstance(NotificationResponseDto, newNotification);
+  }
+
+  async getNotifications(userId: string): Promise<NotificationResponseDto[]> {
+    const notificationList = await this.notificationRepository.findByUserId(userId);
+    return plainToInstance(NotificationResponseDto, notificationList);
+  }
+
+  async checkNotification(id: string): Promise<NotificationResponseDto> {
+    const checkNotification = await this.notificationRepository.updateNotification(id, {
+      isChecked: true,
+    });
+    return plainToInstance(NotificationResponseDto, checkNotification);
+  }
+}

--- a/src/product/product.repository.ts
+++ b/src/product/product.repository.ts
@@ -128,4 +128,36 @@ export const productRepository = {
       },
     });
   },
+  findUsersWithProductAndSizeInCart: async (productId: string, sizeId: number) => {
+    const cartItems = await prisma.cartItem.findMany({
+      where: {
+        productId: productId,
+        sizeId: sizeId,
+      },
+      include: {
+        cart: {
+          select: {
+            buyerId: true, // buyerId만 선택
+          },
+        },
+      },
+    });
+    const userIds = cartItems.map((item) => item.cart.buyerId);
+    const uniqueUserIds = [...new Set(userIds)];
+
+    return uniqueUserIds;
+  },
+  findSellerIdByProductId: async (productId: string) => {
+    const product = await prisma.product.findUnique({
+      where: { id: productId },
+      include: {
+        store: {
+          select: {
+            userId: true,
+          },
+        },
+      },
+    });
+    return product?.store?.userId || null;
+  },
 };


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- PR과 관련된 이슈 번호를 작성 -->
<!-- 작업 사항: 작업 사항들을 간단하게 작성 -->
<!-- 참고자료: Screenshot/GIF, 관련 문서, 링크 등을 작성 -->
<!-- 리뷰어에게: 요청사항이나 참고할 점을 작성 -->


## 🔗 관련 이슈들
- issue #41 

## 🧾 작업 사항
- 문의 api 구현
  - 실시간 알람
  - 알람 조회
  - 알람 읽음 처리
- product 알람 로직 추가 
  - 재고 0으로 변경 시 seller와 buyer에게 알람
  - 재고 0에서 추가될 시 buyer에게 알람
  - 문의 등록 시 seller에게 알람 

## 📎 참고 자료(선택)


## 💬 리뷰어에게(선택)
- 답변 등록은 아직 개발 전이기 때문에 코드를 추가하지 못했습니다. 
- Notification schema 변경하였습니다 (type-enum, size칼럼 추가)
- 테스트는 일부 코드들이 추가 개발된 후 진행하여 공유드리겠습니다.  
- 노션 페이지에는 품절 되었을 때 실시간 알림이 표시되는 것만 나와있으나, 프론트엔드에서는 재입고 시에도 알림을 받고 있어 이 부분도 추가해두었습니다 