### PR TITLE
feat: 문의 api 구현, 로컬테스트 완료, 파일명수정

### DIFF
--- a/src/index.routes.ts
+++ b/src/index.routes.ts
@@ -6,12 +6,14 @@ import authRouter from './auth/auth.routes';
 import StoresRouter from './stores/store.routes';
 import productRouter from './product/product.route';
 import NotificationRouter from './notification/notification.routes';
+import inquiryRouter from './inquiry/inquiry.route';
 
 const router = express.Router();
 
 router.use('/users', userRouter);
 router.use('/auth', authRouter);
 router.use('/products', productRouter);
+router.use('/inquiries', inquiryRouter);
 router.use('/stores', StoresRouter(prisma));
 router.use('/notifications', NotificationRouter(prisma));
 

--- a/src/inquiry/dto/inquiry.dto.ts
+++ b/src/inquiry/dto/inquiry.dto.ts
@@ -1,0 +1,67 @@
+import { InquiryUser } from 'src/product/dto/inquiry.dto';
+import { InquiryStatus } from '@prisma/client';
+import { IsOptional, IsString, IsBoolean, IsNotEmpty } from 'class-validator';
+
+export interface InquiryList {
+  list: InquiryItemDto[];
+  totalCount: number;
+}
+
+export interface getMyInquiriesParams {
+  page?: number;
+  pageSize?: number;
+  status?: InquiryStatus;
+}
+
+export interface InquiryStoreDto {
+  id: string;
+  name: string;
+}
+
+export interface InquiryProductDto {
+  id: string;
+  name: string;
+  image: string;
+  store: InquiryStoreDto;
+}
+
+export interface InquiryItemDto {
+  id: string;
+  title: string;
+  isSecret: boolean;
+  status: InquiryStatus;
+  product: InquiryProductDto;
+  user: InquiryUser;
+  createdAt: Date;
+  content: string;
+}
+
+export class UpdateInquiryDto {
+  @IsOptional()
+  @IsString({ message: '제목은 문자열이어야 합니다.' })
+  title: string;
+
+  @IsOptional()
+  @IsString({ message: '내용은 문자열이어야 합니다.' })
+  content: string;
+
+  @IsOptional()
+  @IsBoolean({ message: '비밀글 여부는 true 또는 false 값이어야 합니다.' })
+  isSecret: boolean;
+}
+
+export class CreateOrUpdateInquiryReplyDto {
+  @IsNotEmpty()
+  @IsString({ message: '답변 내용은 문자열이어야 합니다.' })
+  content: string;
+}
+
+export interface InquiryReplyResponse {
+  id: string;
+  inquiryId: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  user: InquiryUser;
+}

--- a/src/inquiry/inquiry.controller.ts
+++ b/src/inquiry/inquiry.controller.ts
@@ -1,0 +1,119 @@
+import { Request, Response, NextFunction } from 'express';
+import { inquiryService } from './inquiry.service';
+import { InquiryStatus } from '@prisma/client';
+import { getMyInquiriesParams } from './dto/inquiry.dto';
+import { BadRequestError } from 'src/common/errors/error-type';
+
+// 내 문의 리스트 조회
+export const getMyInquiries = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user?.id as string;
+    const params: getMyInquiriesParams = {
+      page: req.query.page ? Number(req.query.page) : 1,
+      pageSize: req.query.pageSize ? Number(req.query.pageSize) : 16,
+      status: (req.query.status ? req.query.status : 'WaitingAnswer') as InquiryStatus,
+    };
+    const myInquiries = await inquiryService.getMyInquiries(userId, params);
+    res.status(200).json(myInquiries);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// 문의 상세 조회
+export const getDetailInquiry = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user?.id as string;
+
+    const inquiryId = req.params.inquiryId;
+    if (!inquiryId) {
+      throw new BadRequestError();
+    }
+    const detailInquiry = await inquiryService.getDetailInquiry(userId, inquiryId);
+    res.status(200).json(detailInquiry);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// 문의 수정
+export const updateInquiry = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user?.id as string;
+    const inquiryId = req.params.inquiryId;
+    if (!inquiryId) {
+      throw new BadRequestError();
+    }
+    const { title, content, isSecret } = req.body;
+    const updateInquiry = await inquiryService.updateInquiry(userId, inquiryId, {
+      title,
+      content,
+      isSecret,
+    });
+    res.status(201).json(updateInquiry);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// 문의 삭제
+export const deleteInquiry = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user?.id as string;
+    const inquiryId = req.params.inquiryId;
+    if (!inquiryId) {
+      throw new BadRequestError();
+    }
+    const deleteInquiry = await inquiryService.deleteInquiry(userId, inquiryId);
+    res.status(200).json(deleteInquiry);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// 문의 답변 생성
+export const postInquiryReply = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user?.id as string;
+    const inquiryId = req.params.inquiryId;
+    if (!inquiryId) {
+      throw new BadRequestError();
+    }
+    const { content } = req.body;
+    const createReply = await inquiryService.postInquiryReply(userId, inquiryId, { content });
+    res.status(201).json(createReply);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// 문의 답변 상세조회
+export const getDetailReply = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user?.id as string;
+    const replyId = req.params.replyId;
+    if (!replyId) {
+      throw new BadRequestError();
+    }
+    const detailReply = await inquiryService.getDetailReply(userId, replyId);
+    res.status(200).json(detailReply);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// 문의 답변 수정
+export const updateReply = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user?.id as string;
+    const replyId = req.params.replyId;
+    if (!replyId) {
+      throw new BadRequestError();
+    }
+    const { content } = req.body;
+    const updateReply = await inquiryService.updateReply(userId, replyId, { content });
+    res.status(200).json(updateReply);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/inquiry/inquiry.repository.ts
+++ b/src/inquiry/inquiry.repository.ts
@@ -9,16 +9,35 @@ export const inquiryRepository = {
     params: { skip: number; take: number; status: InquiryStatus }
   ) => {
     return prisma.inquiry.findMany({
-      where: {
-        userId,
-        status: params.status,
-      },
+      where: { userId, status: params.status },
       skip: params.skip,
       take: params.take,
       orderBy: { createdAt: 'desc' },
-      include: {
-        product: { include: { store: true } },
-        user: { select: { name: true } },
+      select: {
+        id: true,
+        title: true,
+        isSecret: true,
+        status: true,
+        content: true,
+        createdAt: true,
+        product: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+            store: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
+        user: {
+          select: {
+            name: true,
+          },
+        },
       },
     });
   },

--- a/src/inquiry/inquiry.repository.ts
+++ b/src/inquiry/inquiry.repository.ts
@@ -1,0 +1,107 @@
+import prisma from 'src/common/prisma/client';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { InquiryStatus, Prisma } from '@prisma/client';
+import { UpdateInquiryDto, CreateOrUpdateInquiryReplyDto } from './dto/inquiry.dto';
+
+export const inquiryRepository = {
+  findMyInquiryByUserId: (
+    userId: string,
+    params: { skip: number; take: number; status: InquiryStatus }
+  ) => {
+    return prisma.inquiry.findMany({
+      where: {
+        userId,
+        status: params.status,
+      },
+      skip: params.skip,
+      take: params.take,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        product: { include: { store: true } },
+        user: { select: { name: true } },
+      },
+    });
+  },
+
+  countInquiryByUserId: (userId: string, params: { status: InquiryStatus }) => {
+    return prisma.inquiry.count({
+      where: {
+        userId,
+        status: params.status,
+      },
+    });
+  },
+  findInquiryByInquiryId: (inquiryId: string) => {
+    return prisma.inquiry.findUnique({
+      where: { id: inquiryId },
+      include: {
+        user: { select: { name: true } },
+        InquiryReply: { include: { user: { select: { name: true } } } },
+        product: { include: { store: { select: { userId: true } } } },
+      },
+    });
+  },
+  updateInquiry: (inquiryId: string, data: UpdateInquiryDto) => {
+    return prisma.inquiry.update({
+      where: { id: inquiryId },
+      data,
+    });
+  },
+  deleteInquiry: (inquiryId: string) => {
+    return prisma.inquiry.delete({
+      where: { id: inquiryId },
+    });
+  },
+  createReply: (data: { inquiryId: string; userId: string; content: string }) => {
+    return prisma.inquiryReply.create({
+      data: {
+        content: data.content,
+        inquiry: { connect: { id: data.inquiryId } },
+        user: { connect: { id: data.userId } },
+      },
+      include: {
+        user: { select: { id: true, name: true } },
+      },
+    });
+  },
+  findReplyByReplyId: (replyId: string) => {
+    return prisma.inquiryReply.findUnique({
+      where: { id: replyId },
+      include: {
+        user: {
+          select: {
+            name: true,
+          },
+        },
+        inquiry: {
+          include: {
+            user: {
+              select: { name: true },
+            },
+            product: {
+              select: {
+                store: {
+                  select: { userId: true },
+                },
+              },
+            },
+            InquiryReply: {
+              include: {
+                user: { select: { name: true } }, // 답글 작성자 이름
+              },
+            },
+          },
+        },
+      },
+    });
+  },
+  updateReply: (replyId: string, body: CreateOrUpdateInquiryReplyDto) => {
+    return prisma.inquiryReply.update({
+      where: { id: replyId },
+      data: {
+        content: body.content,
+      },
+      include: { user: { select: { id: true, name: true } } },
+    });
+  },
+};

--- a/src/inquiry/inquiry.route.ts
+++ b/src/inquiry/inquiry.route.ts
@@ -1,0 +1,60 @@
+import { Router } from 'express';
+import passport from 'passport';
+import {
+  deleteInquiry,
+  getDetailInquiry,
+  getDetailReply,
+  getMyInquiries,
+  postInquiryReply,
+  updateInquiry,
+  updateReply,
+} from './inquiry.controller';
+import validateDto from 'src/common/utils/validate.dto';
+import { UpdateInquiryDto, CreateOrUpdateInquiryReplyDto } from './dto/inquiry.dto';
+import { authorizeBuyer, authorizeSeller } from 'src/middleware/authorization';
+const router = Router();
+
+// 내 문의 조회 (판매자, 구매자 공용)
+router.get('/', passport.authenticate('jwt', { session: false }), getMyInquiries);
+
+// 문의 상세조회
+router.get('/:inquiryId', passport.authenticate('jwt', { session: false }), getDetailInquiry);
+
+// 문의 수정
+router.patch(
+  '/:inquiryId',
+  validateDto(UpdateInquiryDto),
+  passport.authenticate('jwt', { session: false }),
+  authorizeBuyer,
+  updateInquiry
+);
+
+// 문의 삭제
+router.delete(
+  '/:inquiryId',
+  passport.authenticate('jwt', { session: false }),
+  authorizeBuyer,
+  deleteInquiry
+);
+
+// 문의 답변
+router.post(
+  '/:inquiryId/replies',
+  validateDto(CreateOrUpdateInquiryReplyDto),
+  passport.authenticate('jwt', { session: false }),
+  authorizeSeller,
+  postInquiryReply
+);
+
+// 문의 답변 상세조회
+router.get('/:replyId/replies', passport.authenticate('jwt', { session: false }), getDetailReply);
+
+// 문의 답변 수정
+router.patch(
+  '/:replyId/replies',
+  validateDto(CreateOrUpdateInquiryReplyDto),
+  passport.authenticate('jwt', { session: false }),
+  authorizeSeller,
+  updateReply
+);
+export default router;

--- a/src/inquiry/inquiry.service.ts
+++ b/src/inquiry/inquiry.service.ts
@@ -1,0 +1,241 @@
+import {
+  getMyInquiriesParams,
+  InquiryReplyResponse,
+  UpdateInquiryDto,
+  CreateOrUpdateInquiryReplyDto,
+} from './dto/inquiry.dto';
+import { inquiryRepository } from './inquiry.repository';
+import { InquiryList } from '../inquiry/dto/inquiry.dto';
+import { InquiriesResponse, InquiryResponse } from 'src/product/dto/inquiry.dto';
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+  UnauthorizedError,
+} from 'src/common/errors/error-type';
+import { InquiryStatus } from '@prisma/client';
+
+export const inquiryService = {
+  async getMyInquiries(userId: string, params: getMyInquiriesParams): Promise<InquiryList> {
+    const skip = (params.page! - 1) * params.pageSize!;
+    const take = params.pageSize!;
+
+    const [list, totalCount] = await Promise.all([
+      inquiryRepository.findMyInquiryByUserId(userId, { skip, take, status: params.status! }),
+      inquiryRepository.countInquiryByUserId(userId, { status: params.status! }),
+    ]);
+
+    return { list, totalCount };
+  },
+
+  async getDetailInquiry(userId: string, inquiryId: string): Promise<InquiriesResponse> {
+    const inquiry = await inquiryRepository.findInquiryByInquiryId(inquiryId);
+    if (!inquiry) {
+      throw new NotFoundError();
+    }
+
+    const isSecret = inquiry.isSecret === true;
+
+    if (isSecret) {
+      const isAuthor = inquiry.userId === userId;
+      const isSeller = inquiry.product.store.userId === userId;
+      if (!isAuthor && !isSeller) {
+        throw new UnauthorizedError();
+      }
+    }
+
+    return {
+      id: inquiry.id,
+      userId: inquiry.userId,
+      productId: inquiry.productId,
+      title: inquiry.title,
+      content: inquiry.content,
+      status: inquiry.status,
+      isSecret: inquiry.isSecret,
+      createdAt: inquiry.createdAt,
+      updatedAt: inquiry.updatedAt,
+      user: {
+        name: inquiry.user.name,
+      },
+      reply: inquiry.InquiryReply
+        ? {
+            id: inquiry.InquiryReply.id,
+            content: inquiry.InquiryReply.content,
+            createdAt: inquiry.InquiryReply.createdAt,
+            updatedAt: inquiry.InquiryReply.updatedAt,
+            user: {
+              name: inquiry.InquiryReply.user.name,
+            },
+          }
+        : null,
+    };
+  },
+
+  async updateInquiry(
+    userId: string,
+    inquiryId: string,
+    data: UpdateInquiryDto
+  ): Promise<InquiryResponse> {
+    const inquiry = await inquiryRepository.findInquiryByInquiryId(inquiryId);
+    if (!inquiry) {
+      throw new NotFoundError();
+    }
+
+    const isAuthor = inquiry.userId === userId;
+    if (!isAuthor) {
+      throw new ForbiddenError();
+    }
+
+    if (inquiry.status === InquiryStatus.CompletedAnswer) {
+      throw new BadRequestError();
+    }
+
+    const updateInquiry = await inquiryRepository.updateInquiry(inquiryId, data);
+    return {
+      id: updateInquiry.id,
+      userId: updateInquiry.userId,
+      productId: updateInquiry.productId,
+      title: updateInquiry.title,
+      content: updateInquiry.content,
+      status: updateInquiry.status,
+      isSecret: updateInquiry.isSecret,
+      createdAt: updateInquiry.createdAt,
+      updatedAt: updateInquiry.updatedAt,
+    };
+  },
+
+  async deleteInquiry(userId: string, inquiryId: string): Promise<InquiryResponse> {
+    const inquiry = await inquiryRepository.findInquiryByInquiryId(inquiryId);
+    if (!inquiry) {
+      throw new NotFoundError();
+    }
+
+    const isAuthor = inquiry.userId === userId;
+    if (!isAuthor) {
+      throw new ForbiddenError();
+    }
+
+    const deleteInquiry = await inquiryRepository.deleteInquiry(inquiryId);
+    return {
+      id: deleteInquiry.id,
+      userId: deleteInquiry.userId,
+      productId: deleteInquiry.productId,
+      title: deleteInquiry.title,
+      content: deleteInquiry.content,
+      status: deleteInquiry.status,
+      isSecret: deleteInquiry.isSecret,
+      createdAt: deleteInquiry.createdAt,
+      updatedAt: deleteInquiry.updatedAt,
+    };
+  },
+
+  async postInquiryReply(
+    userId: string,
+    inquiryId: string,
+    body: CreateOrUpdateInquiryReplyDto
+  ): Promise<InquiryReplyResponse> {
+    const inquiry = await inquiryRepository.findInquiryByInquiryId(inquiryId);
+    if (!inquiry) {
+      throw new NotFoundError();
+    }
+
+    const isSeller = inquiry.product.store.userId === userId;
+    if (!isSeller) {
+      throw new ForbiddenError();
+    }
+
+    const { content } = body;
+    if (!content) {
+      throw new BadRequestError();
+    }
+
+    const createReply = await inquiryRepository.createReply({
+      inquiryId,
+      userId,
+      content,
+    });
+
+    return {
+      id: createReply.id,
+      inquiryId: createReply.inquiryId,
+      userId: createReply.userId,
+      content: createReply.content,
+      createdAt: createReply.createdAt.toISOString(),
+      updatedAt: createReply.updatedAt.toISOString(),
+      user: {
+        id: createReply.user.id,
+        name: createReply.user.name,
+      },
+    };
+  },
+
+  async getDetailReply(userId: string, replyId: string): Promise<InquiriesResponse> {
+    const existReply = await inquiryRepository.findReplyByReplyId(replyId);
+    if (!existReply) throw new NotFoundError();
+
+    const inquiry = existReply.inquiry;
+
+    if (inquiry.isSecret) {
+      const isAuthor = inquiry.userId === userId;
+      const isSeller = inquiry.product.store.userId === userId;
+      if (!isAuthor && !isSeller) throw new UnauthorizedError();
+    }
+
+    return {
+      id: inquiry.id,
+      userId: inquiry.userId,
+      productId: inquiry.productId,
+      title: inquiry.title,
+      content: inquiry.content,
+      status: inquiry.status,
+      isSecret: inquiry.isSecret,
+      createdAt: inquiry.createdAt,
+      updatedAt: inquiry.updatedAt,
+      user: {
+        name: inquiry.user.name,
+      },
+      reply: {
+        id: existReply.id,
+        content: existReply.content,
+        createdAt: existReply.createdAt,
+        updatedAt: existReply.updatedAt,
+        user: {
+          name: existReply.user.name,
+        },
+      },
+    };
+  },
+  async updateReply(
+    userId: string,
+    replyId: string,
+    body: CreateOrUpdateInquiryReplyDto
+  ): Promise<InquiryReplyResponse> {
+    const reply = await inquiryRepository.findReplyByReplyId(replyId);
+    if (!reply) {
+      throw new NotFoundError();
+    }
+
+    const isSeller = reply.inquiry.product.store.userId === userId;
+    if (!isSeller) {
+      throw new ForbiddenError();
+    }
+
+    const { content } = body;
+    if (!content) {
+      throw new BadRequestError();
+    }
+    const updateReply = await inquiryRepository.updateReply(replyId, body);
+    return {
+      id: updateReply.id,
+      inquiryId: updateReply.inquiryId,
+      userId: updateReply.userId,
+      content: updateReply.content,
+      createdAt: updateReply.createdAt.toISOString(),
+      updatedAt: updateReply.updatedAt.toISOString(),
+      user: {
+        id: updateReply.user.id,
+        name: updateReply.user.name,
+      },
+    };
+  },
+};

--- a/src/product/dto/inquiry.dto.ts
+++ b/src/product/dto/inquiry.dto.ts
@@ -31,6 +31,7 @@ export interface InquiryResponse {
 export interface InquiriesResponse {
   id: string;
   userId: string;
+  productId: string;
   title: string;
   content: string;
   status: InquiryStatus;
@@ -42,6 +43,7 @@ export interface InquiriesResponse {
 }
 
 export interface InquiryUser {
+  id?: string;
   name: string;
 }
 

--- a/src/product/product.repository.ts
+++ b/src/product/product.repository.ts
@@ -1,6 +1,6 @@
 import prisma from 'src/common/prisma/client';
 import { InquiryStatus, Prisma } from '@prisma/client';
-import { CreateInquiryDto } from './dto/inquity.dto';
+import { CreateInquiryDto } from './dto/inquiry.dto';
 export const productRepository = {
   create: (data: Prisma.ProductCreateInput) =>
     prisma.product.create({

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -10,7 +10,7 @@ import {
   ReviewDto,
 } from './dto/product.dto';
 import { NotificationType, Prisma, PrismaClient } from '@prisma/client';
-import { CreateInquiryDto, InquiriesResponse, InquiryResponse } from './dto/inquity.dto';
+import { CreateInquiryDto, InquiriesResponse, InquiryResponse } from './dto/inquiry.dto';
 import { NotificationRepository } from 'src/notification/notification.repository';
 import { NotificationService } from 'src/notification/notification.service';
 import { CreateNotificationDto } from 'src/notification/dto/create.dto';


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- PR과 관련된 이슈 번호를 작성 -->
<!-- 작업 사항: 작업 사항들을 간단하게 작성 -->
<!-- 참고자료: Screenshot/GIF, 관련 문서, 링크 등을 작성 -->
<!-- 리뷰어에게: 요청사항이나 참고할 점을 작성 -->


## 🔗 관련 이슈들
- issue #44 
## 🧾 작업 사항
- 문의 api 구현
- 문의 dto 파일이름에 오타가 있어 수정하였습니다.
- swagger상에 적힌 기능대로 파일을 분리했습니다 ex) 상품 문의 등록, 상품 문의 조회는 product 폴더 내부, 필요한 inquiry.dto 도 product 폴더 내부
- 문의 상세 조회, 문의 수정, 답변 생성, 답변 수정, 내 문의 리스트 조회 ,문의 삭제 기능을 추가하고 로컬테스트를 완료했습니다
- 문의 답변 삭제는 swagger에 없어 일단 만들지 않았습니다.
- src 내부에 inquiry.dto 파일이 두개(product, inquiry 폴더 내부 )인데  서로 공유하는 내용은 import해서 사용했습니다 다른 아이디어 있으면 말씀해주세요

## 📎 참고 자료(선택)
- 수정할 것과 추가해야될 점 피드백 부탁드립니다 ! 


## 💬 리뷰어에게(선택)
