### PR TITLE
refactor: product api 에 s3업로드 적용

### DIFF
--- a/src/product/dto/product.dto.ts
+++ b/src/product/dto/product.dto.ts
@@ -1,4 +1,4 @@
-import { Type } from 'class-transformer';
+import { Type, Transform, plainToInstance } from 'class-transformer';
 import {
   IsArray,
   IsDate,
@@ -94,6 +94,18 @@ export class CreateProductDto {
   @ValidateNested({ each: true })
   @IsNotEmpty({ message: '상품이름은 필수 입력 항목입니다.' })
   @Type(() => StocksDto)
+  @Transform(({ value }): StocksDto[] => {
+    if (typeof value === 'string') {
+      try {
+        const parsed = JSON.parse(value);
+        // 배열이면 StocksDto로 매핑
+        return Array.isArray(parsed) ? plainToInstance(StocksDto, parsed) : [];
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  })
   stocks: StocksDto[];
 }
 
@@ -139,6 +151,19 @@ export class UpdateProductDto {
 
   @IsArray({ message: 'stocks는 배열이어야 합니다.' })
   @ValidateNested({ each: true })
+  @Type(() => StocksDto)
+  @Transform(({ value }): StocksDto[] => {
+    if (typeof value === 'string') {
+      try {
+        const parsed = JSON.parse(value);
+        // 배열이면 StocksDto로 매핑
+        return Array.isArray(parsed) ? plainToInstance(StocksDto, parsed) : [];
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  })
   stocks?: StocksDto[];
 }
 

--- a/src/product/product.route.ts
+++ b/src/product/product.route.ts
@@ -12,15 +12,18 @@ import {
 } from './product.controller';
 import { CreateProductDto, UpdateProductDto } from './dto/product.dto';
 import { authorizeBuyer, authorizeSeller } from 'src/middleware/authorization';
+import { s3Upload, mapFileToBody } from '../middleware/s3-upload';
 
 const router = Router();
 
 // 상품 등록
 router.post(
   '/',
-  validateDto(CreateProductDto),
   passport.authenticate('jwt', { session: false }),
   authorizeSeller,
+  s3Upload.single('image'),
+  mapFileToBody,
+  validateDto(CreateProductDto),
   createProduct
 );
 
@@ -33,9 +36,11 @@ router.get('/:productId', getProductDetail);
 // 상품 수정
 router.patch(
   '/:productId',
-  validateDto(UpdateProductDto),
   passport.authenticate('jwt', { session: false }),
   authorizeSeller,
+  s3Upload.single('image'),
+  mapFileToBody,
+  validateDto(UpdateProductDto),
   updateProduct
 );
 


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- PR과 관련된 이슈 번호를 작성 -->
<!-- 작업 사항: 작업 사항들을 간단하게 작성 -->
<!-- 참고자료: Screenshot/GIF, 관련 문서, 링크 등을 작성 -->
<!-- 리뷰어에게: 요청사항이나 참고할 점을 작성 -->


## 🔗 관련 이슈들
- issue #49 

## 🧾 작업 사항
- product api 코드에 s3 이미지 업로드를 적용했습니다.
- DTO에서 image 필드를 검증할 수 있도록, 라우터에 `mapFileToBody` 미들웨어를 추가했습니다.
  - multer-s3는 업로드된 이미지 파일을 req.file로 전달하지만, 이 객체를 그대로 사용하면 DTO에서 검증할 수 없습니다.   
    따라서 `mapFileToBody`미들웨어에서 req.file.location 값을 req.body.image에 매핑하여 DTO 검증이 가능하도록 했습니다.

- 프론트엔드에서는 `/api/upload/` 같은 업로드 전용 API를 사용하지 않고, 이미지 업로드가 필요한 경우 모든 필드를 FormData 형식으로 전달하고 있습니다.  
 FormData는 text, file만 지원하기 때문에 텍스트 값은 모두 문자열로 전송됩니다. 이 과정에서 배열도 문자열로 들어오기 때문에, 서버에서 JSON.parse로 파싱한 뒤 DTO 형태로 변환하는 로직을 추가했습니다.
## 📎 참고 자료(선택)


## 💬 리뷰어에게(선택)
