### PR TITLE
test: 유저 유닛 테스트 코드 추가

### DIFF
--- a/tests/unit/auth.repository.test.ts
+++ b/tests/unit/auth.repository.test.ts
@@ -1,5 +1,5 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { PrismaClient, Prisma } from '@prisma/client';
+import { PrismaClient, Prisma, UserType } from '@prisma/client';
 import AuthRepository from '../../src/auth/auth.repository';
 
 describe('AuthRepository Unit Test', () => {
@@ -22,7 +22,7 @@ describe('AuthRepository Unit Test', () => {
     password: '$2b$10$hashed',
     image: 'http://example.com/img.png',
     points: 0,
-    type: 'BUYER',
+    type: UserType.BUYER,
     gradeid: 'grade_green',
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/tests/unit/auth.service.test.ts
+++ b/tests/unit/auth.service.test.ts
@@ -4,6 +4,7 @@ import AuthService from '../../src/auth/auth.service';
 import AuthRepository from '../../src/auth/auth.repository';
 import { NotFoundError, UnauthorizedError } from '../../src/common/errors/error-type';
 import { LoginDto } from '../../src/auth/dtos/login.dto';
+import { UserType } from '@prisma/client';
 
 jest.mock('../../src/auth/jwt', () => ({
   generateAccessToken: jest.fn(),
@@ -35,7 +36,7 @@ describe('AuthService Unit Test', () => {
     password: '$2b$10$hashed',
     image: 'http://example.com/img.png',
     points: 0,
-    type: 'SELLER' as const,
+    type: UserType.BUYER,
     gradeid: 'grade_green',
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/tests/unit/user.repository.test.ts
+++ b/tests/unit/user.repository.test.ts
@@ -1,0 +1,153 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { PrismaClient, Prisma, UserType } from '@prisma/client';
+import UserRepository from '../../src/users/user.repository';
+
+describe('UserRepository Unit Test', () => {
+  let prisma: DeepMockProxy<PrismaClient>;
+  let repository: UserRepository;
+
+  type UserWithGrade = Prisma.UserGetPayload<{ include: { grade: true } }>;
+  type StoreLikeWithStore = Prisma.StoreLikeGetPayload<{ include: { store: true } }>;
+
+  const grade = {
+    id: 'grade_green',
+    name: 'green',
+    rate: 5,
+    minAmount: 0,
+  };
+
+  const user: UserWithGrade = {
+    id: 'u1',
+    name: '테스터',
+    email: 'test@example.com',
+    password: '$2b$10$hashed',
+    image: 'http://example.com/img.png',
+    points: 0,
+    type: UserType.BUYER,
+    gradeid: 'grade_green',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isDeleted: false,
+    grade,
+  };
+
+  beforeEach(() => {
+    prisma = mockDeep<PrismaClient>();
+    repository = new UserRepository(prisma as unknown as PrismaClient);
+    jest.clearAllMocks();
+  });
+
+  test('findByEmail - 이메일로 사용자 조회', async () => {
+    prisma.user.findUnique.mockResolvedValue(user);
+
+    const result = await repository.findByEmail(user.email);
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { email: user.email },
+    });
+    expect(result).toEqual(user);
+  });
+
+  test('findByEmail - 결과 없음이면 null 반환', async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    const result = await repository.findByEmail('notfound@test.com');
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { email: 'notfound@test.com' },
+    });
+    expect(result).toBeNull();
+  });
+
+  test('create - 유저 생성 시 grade 포함 반환', async () => {
+    prisma.user.create.mockResolvedValue(user);
+
+    const result = await repository.create({
+      name: user.name,
+      email: user.email,
+      password: user.password,
+      type: user.type,
+      grade: { connect: { id: grade.id } },
+    });
+
+    expect(prisma.user.create).toHaveBeenCalledWith({
+      data: expect.any(Object),
+      include: { grade: true },
+    });
+    expect(result).toEqual(user);
+  });
+
+  test('getUserById - 아이디로 조회', async () => {
+    prisma.user.findUnique.mockResolvedValue(user);
+
+    const result = await repository.getUserById(user.id);
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: user.id },
+      include: { grade: true },
+    });
+    expect(result).toEqual(user);
+  });
+
+  test('updateUser - 유저 업데이트', async () => {
+    const updated: UserWithGrade = { ...user, name: '변경됨' };
+    prisma.user.update.mockResolvedValue(updated);
+
+    const result = await repository.updateUser(user.id, { name: '변경됨' });
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: user.id },
+      data: { name: '변경됨' },
+      include: { grade: true },
+    });
+    expect(result).toEqual(updated);
+  });
+
+  test('getUserLikedStores - 관심 스토어 반환', async () => {
+    const storeLike: StoreLikeWithStore[] = [
+      {
+        id: 'like1',
+        userId: user.id,
+        storeId: 's1',
+        createdAt: new Date(),
+        store: {
+          id: 's1',
+          name: '스토어',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: 'owner1',
+          address: '서울시',
+          detailAddress: '어딘가',
+          phoneNumber: '010-1234-5678',
+          content: '테스트용',
+          image: 'http://example.com/store.png',
+          productCount: 0,
+          favoriteCount: 0,
+          monthFavoriteCount: 0,
+          totalSoldCount: 0,
+          isDeleted: false,
+        },
+      },
+    ];
+    prisma.storeLike.findMany.mockResolvedValue(storeLike);
+
+    const result = await repository.getUserLikedStores(user.id);
+
+    expect(prisma.storeLike.findMany).toHaveBeenCalledWith({
+      where: { userId: user.id },
+      include: { store: true },
+    });
+    expect(result).toEqual(storeLike);
+  });
+
+  test('deleteUser - 유저 삭제', async () => {
+    prisma.user.delete.mockResolvedValue(user);
+
+    const result = await repository.deleteUser(user.id);
+
+    expect(prisma.user.delete).toHaveBeenCalledWith({
+      where: { id: user.id },
+    });
+    expect(result).toEqual(user);
+  });
+});

--- a/tests/unit/user.service.test.ts
+++ b/tests/unit/user.service.test.ts
@@ -1,0 +1,173 @@
+import { type MockProxy, mock } from 'jest-mock-extended';
+import bcrypt from 'bcrypt';
+import UserService from '../../src/users/user.service';
+import UserRepository from '../../src/users/user.repository';
+import {
+  ConflictError,
+  NotFoundError,
+  UnauthorizedError,
+} from '../../src/common/errors/error-type';
+import { Prisma, UserType } from '@prisma/client';
+import { CreateUserDto } from '../../src/users/dtos/create-user.dto';
+import { UpdateUserDto } from '../../src/users/dtos/update-user.dto';
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}));
+
+describe('UserService Unit Test', () => {
+  let userRepository: MockProxy<UserRepository>;
+  let userService: UserService;
+
+  type UserWithGrade = Prisma.UserGetPayload<{ include: { grade: true } }>;
+  type StoreLikeWithStore = Prisma.StoreLikeGetPayload<{ include: { store: true } }>;
+
+  const grade = {
+    id: 'grade_green',
+    name: 'green',
+    rate: 5,
+    minAmount: 0,
+  };
+
+  const user: UserWithGrade = {
+    id: 'u1',
+    name: '테스터',
+    email: 'test@example.com',
+    password: '$2b$10$hashed',
+    image: 'http://example.com/img.png',
+    points: 0,
+    type: UserType.BUYER,
+    gradeid: 'grade_green',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isDeleted: false,
+    grade,
+  };
+
+  beforeEach(() => {
+    userRepository = mock<UserRepository>();
+    userService = new UserService(userRepository);
+    jest.clearAllMocks();
+  });
+
+  test('createUser - 이메일 중복 시 ConflictError', async () => {
+    userRepository.findByEmail.mockResolvedValue(user);
+    const dto: CreateUserDto = {
+      name: '테스터',
+      email: user.email,
+      password: '123456',
+      type: UserType.BUYER,
+    };
+
+    await expect(userService.createUser(dto)).rejects.toThrow(ConflictError);
+  });
+
+  test('createUser - 성공 시 유저 생성', async () => {
+    userRepository.findByEmail.mockResolvedValue(null);
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed_pw');
+    userRepository.create.mockResolvedValue(user);
+
+    const dto: CreateUserDto = {
+      name: '테스터',
+      email: user.email,
+      password: '123456',
+      type: UserType.BUYER,
+    };
+
+    const result = await userService.createUser(dto);
+    expect(userRepository.create).toHaveBeenCalled();
+    expect(result.email).toBe(user.email);
+  });
+
+  test('getUser - 유저 없음 시 NotFoundError', async () => {
+    userRepository.getUserById.mockResolvedValue(null);
+
+    await expect(userService.getUser('u999')).rejects.toThrow(NotFoundError);
+  });
+
+  test('getUser - 유저가 존재하면 반환', async () => {
+    userRepository.getUserById.mockResolvedValue(user);
+
+    const result = await userService.getUser(user.id);
+    expect(result.id).toBe(user.id);
+    expect(result.email).toBe(user.email);
+  });
+
+  test('updateUser - 비밀번호 불일치 시 UnauthorizedError', async () => {
+    userRepository.getUserById.mockResolvedValue(user);
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+    const dto: UpdateUserDto = { currentPassword: 'wrong' };
+
+    await expect(userService.updateUser(user.id, dto)).rejects.toThrow(UnauthorizedError);
+  });
+
+  test('updateUser - 비밀번호 일치 시 업데이트 성공', async () => {
+    userRepository.getUserById.mockResolvedValue(user);
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+    const updatedUser = { ...user, name: '업데이트된 유저' };
+    userRepository.updateUser.mockResolvedValue(updatedUser);
+
+    const dto: UpdateUserDto = { currentPassword: '123456', name: '업데이트된 유저' };
+
+    const result = await userService.updateUser(user.id, dto);
+
+    expect(userRepository.updateUser).toHaveBeenCalledWith(user.id, expect.any(Object));
+    expect(result.name).toBe('업데이트된 유저');
+  });
+
+  test('getUserLikedStores - 결과 없음 시 NotFoundError', async () => {
+    userRepository.getUserLikedStores.mockResolvedValue([]);
+
+    await expect(userService.getUserLikedStores(user.id)).rejects.toThrow(NotFoundError);
+  });
+
+  test('getUserLikedStores - 관심 스토어가 있으면 반환', async () => {
+    const likedStores: StoreLikeWithStore[] = [
+      {
+        id: 'like1',
+        userId: user.id,
+        storeId: 'store1',
+        createdAt: new Date(),
+        store: {
+          id: 'store1',
+          name: '하이버',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          userId: user.id,
+          address: '서울시 강남구',
+          detailAddress: '역삼동',
+          phoneNumber: '010-1234-5678',
+          content: '테스트',
+          image: 'https://example.com/store1.png',
+          productCount: 0,
+          favoriteCount: 0,
+          monthFavoriteCount: 0,
+          totalSoldCount: 0,
+          isDeleted: false,
+        },
+      },
+    ];
+
+    userRepository.getUserLikedStores.mockResolvedValue(likedStores);
+
+    const result = await userService.getUserLikedStores(user.id);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.storeId).toBe('store1');
+  });
+
+  test('deleteUser - 유저 없음 시 NotFoundError', async () => {
+    userRepository.getUserById.mockResolvedValue(null);
+
+    await expect(userService.deleteUser(user.id)).rejects.toThrow(NotFoundError);
+  });
+
+  test('deleteUser - 유저 존재 시 성공 메시지 반환', async () => {
+    userRepository.getUserById.mockResolvedValue(user);
+
+    const result = await userService.deleteUser(user.id);
+    expect(result).toEqual({ message: '회원 탈퇴가 완료되었습니다.' });
+  });
+});


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- PR과 관련된 이슈 번호를 작성 -->
<!-- 작업 사항: 작업 사항들을 간단하게 작성 -->
<!-- 참고자료: Screenshot/GIF, 관련 문서, 링크 등을 작성 -->
<!-- 리뷰어에게: 요청사항이나 참고할 점을 작성 -->


## 🔗 관련 이슈들
- issue #74 
- issue #73 

## 🧾 작업 사항
- 유저 유닛 테스트 코드를 추가 했습니다.
- 인증 테스트코드의 유저 더미데이터의 유저타입을 정의된 enum에서 받아오게 수정했습니다.
## 📎 참고 자료(선택)
<img width="464" height="398" alt="image" src="https://github.com/user-attachments/assets/f9d83796-1f80-431d-a4cb-ed32106eaa82" />

## 💬 리뷰어에게(선택)
