### PR TITLE
fix/store

### DIFF
--- a/src/stores/stores.controller.ts
+++ b/src/stores/stores.controller.ts
@@ -90,11 +90,20 @@ export default class StoreController {
       const page = Number(req.query.page) || 1;
       const pageSize = Number(req.query.pageSize) || 10;
 
-      const productList = await this.storeService.getMyStoreProducts(userId, page, pageSize);
-      const productListResponse = plainToInstance(ProductResponseDto, productList, {
+      const { list, totalCount } = await this.storeService.getMyStoreProducts(
+        userId,
+        page,
+        pageSize
+      );
+
+      const productListResponse = plainToInstance(ProductResponseDto, list, {
         excludeExtraneousValues: true,
       });
-      return res.status(200).json(productListResponse);
+
+      return res.status(200).json({
+        list: productListResponse, // DTO 변환된 리스트
+        totalCount: totalCount, // 전체 개수
+      });
     } catch (error) {
       return next(error);
     }

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -97,15 +97,12 @@ export default class StoreService {
       throw new NotFoundError('존재하지 않는 스토어입니다.');
     }
 
-    const productsWithStock = await this.storeRepository.findMyStoreProducts(
-      userId,
-      page,
-      pageSize
-    );
+    const productsWithStock =
+      (await this.storeRepository.findMyStoreProducts(userId, page, pageSize)) || [];
     const totalCount = await this.storeRepository.countMyStoreProducts(userId);
 
     const productInfo = productsWithStock.map((product) => {
-      const stock = product.Stock.reduce((sum, current) => sum + current.quantity, 0);
+      const stock = (product.Stock || []).reduce((sum, current) => sum + current.quantity, 0);
       const isDiscount =
         (product.discountRate ?? 0) > 0 &&
         product.discountEndTime !== null &&


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- PR과 관련된 이슈 번호를 작성 -->
<!-- 작업 사항: 작업 사항들을 간단하게 작성 -->
<!-- 참고자료: Screenshot/GIF, 관련 문서, 링크 등을 작성 -->
<!-- 리뷰어에게: 요청사항이나 참고할 점을 작성 -->


## 🔗 관련 이슈들
- issue #83 

## 🧾 작업 사항
- 프론트엔드 연동 시 my-store의 상품목록 페이지 500 에러 수정 

## 📎 참고 자료(선택)
수정 완료
<img width="1621" height="587" alt="상품목록 에러 수정 완료" src="https://github.com/user-attachments/assets/68d6c81e-1ec4-4e5f-bcee-89df1bbe221c" />

- 컨트롤러에서 DTO 변환을 전체 응답 객체에 적용하여 { list, totalCount } 구조가 깨짐. 
 -> DTO 변환을 list 배열에만 적용하도록 바꾸고, 최종 응답을 { list: DTO_LIST, totalCount: COUNT } 형태로 명시적으로 재구성하여 프론트엔드 응답 형태와 통일시켰습니다.

## 💬 리뷰어에게(선택)
