### PR TITLE
fix: 유저의 의미없는 이미지텍스트를 실제 대체 이미지로 변경

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,7 @@ model User {
   name      String   @db.VarChar(20)
   email     String   @unique @db.VarChar(100)
   password  String   @db.VarChar(255)
-  image     String?  @default("https://example.com/default.png") // 추후 기본값 수정
+  image     String?  @default("https://placehold.co/400.jpg?text=user")
   points    Int      @default(0)
   type      UserType
   createdAt DateTime @default(now())


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- PR과 관련된 이슈 번호를 작성 -->
<!-- 작업 사항: 작업 사항들을 간단하게 작성 -->
<!-- 참고자료: Screenshot/GIF, 관련 문서, 링크 등을 작성 -->
<!-- 리뷰어에게: 요청사항이나 참고할 점을 작성 -->


## 🔗 관련 이슈들
- issue #89 

## 🧾 작업 사항
- 유저의 의미없는 기본 이미지 텍스트를 실제 대체 이미지로 변경 했습니다.  
  사용 사이트 [placeholder](https://placehold.co/) 
## 📎 참고 자료(선택)
<img width="399" height="93" alt="image" src="https://github.com/user-attachments/assets/43459de2-d658-4280-a244-84a4cce570ee" />


## 💬 리뷰어에게(선택)
스키마 변경으로 마이그레이션과 시딩 필요합니다
