### PR TITLE
fix: 관심 스토어 조회 에러 수정

### DIFF
--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -71,7 +71,7 @@ export default class UserService {
     const likedStores = await this.userRepository.getUserLikedStores(userId);
 
     if (!likedStores || likedStores.length === 0) {
-      throw new NotFoundError('관심 스토어가 없습니다.');
+      return [];
     }
 
     return likedStores.map((like) => ({


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- PR과 관련된 이슈 번호를 작성 -->
<!-- 작업 사항: 작업 사항들을 간단하게 작성 -->
<!-- 참고자료: Screenshot/GIF, 관련 문서, 링크 등을 작성 -->
<!-- 리뷰어에게: 요청사항이나 참고할 점을 작성 -->


## 🔗 관련 이슈들
- issue #99 

## 🧾 작업 사항
- 관심 스토어 조회시 관심 스토어가 없으면 에러가 나는 코드를 수정했습니다.
- 기존에는 관심스토어가 없으면 에러취급으로 핸들러로 에러를 던졌지만, 빈 배열을 반환하도록 변경했습니다.

