### PR TITLE
refactor: 분리했던 env 파일 재 통합

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,4 @@
-#.env.dev
-
-NODE_ENV=development
+#.env
 PORT=0
 DATABASE_URL=postgresql://<username>:<password>@<host>:<port>/<database>
 JWT_ACCESS_SECRET=access_secret
@@ -9,12 +7,8 @@ AWS_REGION=ap-northeast-2
 AWS_ACCESS_KEY_ID=access-key-id
 AWS_SECRET_ACCESS_KEY=secret-access-key
 AWS_BUCKET_NAME=bucket-name
-COOKIE_SECURE=false
-COOKIE_SAMESITE=lax
 
 #.env.prod
-
-NODE_ENV=production
 PORT=0
 DATABASE_URL=postgresql://<username>:<password>@<host>:<port>/<database>
 JWT_ACCESS_SECRET=access_secret
@@ -23,6 +17,4 @@ AWS_REGION=ap-northeast-2
 AWS_ACCESS_KEY_ID=access-key-id
 AWS_SECRET_ACCESS_KEY=secret-access-key
 AWS_BUCKET_NAME=bucket-name
-COOKIE_SECURE=true
-COOKIE_SAMESITE=none
 FRONTEND_URL=

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "scripts": {
     "build": "rm -rf dist/* && tsc",
     "start": "NODE_ENV=production node dist/src/server.js",
-    "dev": "NODE_ENV=development nodemon --watch src --ext ts --exec ts-node -r tsconfig-paths/register --files src/server.ts",
-    "seed": "NODE_ENV=development ts-node prisma/seed.ts",
-    "seed:prod": "NODE_ENV=production ts-node prisma/seed.ts",
+    "dev": "nodemon --watch src --ext ts --exec ts-node -r tsconfig-paths/register --files src/server.ts",
+    "seed": "ts-node prisma/seed.ts",
     "reset": "npx prisma migrate reset -f",
     "migrate": "npx prisma migrate dev",
     "lint": "npx eslint --fix .",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,12 +1,5 @@
 import prisma from '../src/common/prisma/client';
 import bcrypt from 'bcrypt';
-import dotenv from 'dotenv';
-
-if (process.env.NODE_ENV === 'production') {
-  dotenv.config({ path: '.env.prod' });
-} else {
-  dotenv.config({ path: '.env.dev' });
-}
 
 async function main() {
   const grades = [

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,11 +1,7 @@
 import dotenv from 'dotenv';
 import { InternalServerError } from '../common/errors/error-type';
 
-if (process.env.NODE_ENV === 'production') {
-  dotenv.config({ path: '.env.prod' });
-} else {
-  dotenv.config({ path: '.env.dev' });
-}
+dotenv.config();
 
 function requireEnv(env: string): string {
   const envValue = process.env[env];
@@ -22,5 +18,7 @@ export const AWS_REGION = requireEnv('AWS_REGION');
 export const AWS_ACCESS_KEY_ID = requireEnv('AWS_ACCESS_KEY_ID');
 export const AWS_SECRET_ACCESS_KEY = requireEnv('AWS_SECRET_ACCESS_KEY');
 export const AWS_BUCKET_NAME = requireEnv('AWS_BUCKET_NAME');
-export const COOKIE_SECURE = requireEnv('COOKIE_SECURE') === 'true';
-export const COOKIE_SAMESITE = requireEnv('COOKIE_SAMESITE') as 'lax' | 'none';
+
+export const IS_PROD = process.env.NODE_ENV === 'production';
+export const COOKIE_SECURE = IS_PROD ? true : false;
+export const COOKIE_SAMESITE = IS_PROD ? 'none' : 'lax';


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- PR과 관련된 이슈 번호를 작성 -->
<!-- 작업 사항: 작업 사항들을 간단하게 작성 -->
<!-- 참고자료: Screenshot/GIF, 관련 문서, 링크 등을 작성 -->
<!-- 리뷰어에게: 요청사항이나 참고할 점을 작성 -->


## 🔗 관련 이슈들
- issue #106 

## 🧾 작업 사항
- .env.dev, .env.prod 로 구분했던 파일을 기존의 .env 파일 하나로 사용할 수 있게 재 변경 했습니다

- 배포시에 활용하기 위해 .env 파일을 구분해서 나누었지만, 배포시 깃허브 액션에 환경변수를 등록해서 사용할 수도 있고,
 개발시에는 db관련 스크립트가 env 설정별로 무의미하게 많아지고 복잡해지기 때문에  다시 원상복구했습니다.


## 💬 리뷰어에게(선택)
기존처럼 .env 하나로 사용하시면 됩니다!  죄송합니다
env.example 의 .env.prod 는 배포때 참고용으로 놔두었습니다.
